### PR TITLE
pin shapely <2.0.0 (temporary fix) so the package builds and installs correctly

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -42,7 +42,7 @@ outputs:
         - dask
         - ecmwf-api-client
         - eofs
-        - esmpy
+        - esmpy <8.4  # github.com/ESMValGroup/ESMValCore/issues/1870
         - esmvalcore 2.7.*
         - fiona
         - fire

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -75,7 +75,8 @@ outputs:
         - requests
         - ruamel.yaml
         - scikit-image
-        - scikit-learn
+        # remove this pin at release; this uses older, deprecated code
+        - scikit-learn <1.2.0  # github.com/ESMValGroup/ESMValTool/pull/2961
         - scipy
         - seaborn
         - seawater

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 397f0e94d0f75112d159dad4e7fb6a16594e07749590fcef163eb99f10b10f1b
 
 build:
-  number: 1
+  number: 2
 
 outputs:
   - name: esmvaltool-python
@@ -79,7 +79,7 @@ outputs:
         - scipy
         - seaborn
         - seawater
-        - shapely
+        - shapely <2.0.0  # github.com/ESMValGroup/ESMValTool/issues/2992
         - xarray >=0.12.0
         - xesmf =0.3.0
         - xgboost >1.6.1


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
~* [ ] Reset the build number to `0` (if the version changed)~
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

Issue documented (specifically to ESMValTool) in https://github.com/ESMValGroup/ESMValTool/issues/2992 but do have a look at the ESMValCore issue linked from within. This pin should ideally be suppressed once the Shapely guys do something about itor we have patched and rebuilt Core (hopefully not the case).
